### PR TITLE
fix: remove `v` from `$PREFIX` when downloading

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -51,6 +51,7 @@ jobs:
         if: steps.check_version.outputs.exit != 'true'
         run: |
           PREFIX=${{ steps.check_version.outputs.version }}
+          PREFIX=${PREFIX#v}
           ARCHS=("arm" "arm64")
           mkdir -p files
           cd files


### PR DESCRIPTION
The recent actions are failing. This fixes it by removing the `v` prefix from the download URL.