### PR TITLE
settings.ini: fix getent not reachable by tailscaled

### DIFF
--- a/tailscale/settings.ini
+++ b/tailscale/settings.ini
@@ -5,12 +5,12 @@
 module_dir="/data/adb/modules/magisk-tailscaled" # Bad code, if magisk in the future change the path location, need to change this.
 module_prop="${module_dir}/module.prop"
 
-# Set path environment for busybox & other.
-export PATH="/data/adb/magisk:/data/adb/ksu/bin:$PATH:/system/bin:${module_dir}/system/bin"
-export HOME="/data/adb/tailscale/tmp/" # Because tailscaled will write log to $HOME
-
 # Set tailscale directory variables
 tailscale_dir="/data/adb/tailscale"
+
+# Set path environment for busybox & other.
+export PATH="/data/adb/magisk:/data/adb/ksu/bin:$PATH:/system/bin:${module_dir}/system/bin:${tailscale_dir}/bin"
+export HOME="/data/adb/tailscale/tmp/" # Because tailscaled will write log to $HOME
 
 # Set tailscale & tailscaled binary variables
 tailscale_bin="${tailscale_dir}/bin/tailscale"


### PR DESCRIPTION
Currently the drop-in `getent` replacement is placed in `/data/adb/tailscale/bin/getent`, not reachable by `tailscaled` since `/data/adb/tailscale/bin` is not in the `$PATH`.

The error looks like this:
```
failed to look up root
root@<hostname>: Permission denied (tailscale).
```

This PR fixes the issue by prepending `${tailscale_dir}/bin` to `$PATH`.