### PR TITLE
Fix module service.d directory in KernelSU

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -11,9 +11,6 @@ elif [ "$KSU" = true ] && [ "$KSU_VER_CODE" -lt 10670 ]; then
 fi
 
 SERVICE_DIR="/data/adb/service.d"
-if [ "$KSU" = true ]; then
-  SERVICE_DIR="/data/adb/ksu/service.d"
-fi
 
 CUSTOM_DIR="/data/adb/tailscale"
 CUSTOM_BIN_DIR="$CUSTOM_DIR/bin"


### PR DESCRIPTION
KernelSU has the same directory with Magisk long time ago [v0.4.0](https://github.com/tiann/KernelSU/commit/ee09b9f9f4c1b42da3af5cc4df96629e4f6c0745) 