### PR TITLE
feat: replace the owner and repository name with github context

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,16 +149,16 @@ jobs:
         sed -i "s/^versionCode=.*/versionCode=$newVersionCode/" module.prop
 
         # Estimate the zip url location
-        zipUrl="https://github.com/anasfanani/Magisk-Tailscaled/releases/download/$versionString/Magisk-Tailscaled-$versionString.zip" # Universal
-        zipUrl_arm="https://github.com/anasfanani/Magisk-Tailscaled/releases/download/$versionString/Magisk-Tailscaled-arm-$versionString.zip" # Arm
-        zipUrl_arm64="https://github.com/anasfanani/Magisk-Tailscaled/releases/download/$versionString/Magisk-Tailscaled-arm64-$versionString.zip" # Arm64
+        zipUrl="https://github.com/${{ github.repository }}/releases/download/$versionString/Magisk-Tailscaled-$versionString.zip" # Universal
+        zipUrl_arm="https://github.com/${{ github.repository }}/releases/download/$versionString/Magisk-Tailscaled-arm-$versionString.zip" # Arm
+        zipUrl_arm64="https://github.com/${{ github.repository }}/releases/download/$versionString/Magisk-Tailscaled-arm64-$versionString.zip" # Arm64
 
         # Update update.json
         jq '.version = $newVersion | .versionCode = $newVersionCode | .zipUrl = $newZipUrl | .changelog = $newChangelog' \
           --arg newVersion "${versionString}" \
           --arg newVersionCode "$newVersionCode" \
           --arg newZipUrl "$zipUrl" \
-          --arg newChangelog "https://raw.githubusercontent.com/anasfanani/Magisk-Tailscaled/master/CHANGELOG.md" \
+          --arg newChangelog "https://raw.githubusercontent.com/${{ github.repository }}/master/CHANGELOG.md" \
           update.json > temp.json && mv temp.json update.json
 
         # Update update-arm.json
@@ -167,7 +167,7 @@ jobs:
           --arg newVersion "${versionString}-arm" \
           --arg newVersionCode "$newVersionCode" \
           --arg newZipUrl "$zipUrl_arm" \
-          --arg newChangelog "https://raw.githubusercontent.com/anasfanani/Magisk-Tailscaled/master/CHANGELOG.md" \
+          --arg newChangelog "https://raw.githubusercontent.com/${{ github.repository }}/master/CHANGELOG.md" \
           update-arm.json > temp.json && mv temp.json update-arm.json
 
         # Update update-arm64.json
@@ -176,7 +176,7 @@ jobs:
           --arg newVersion "${versionString}-arm64" \
           --arg newVersionCode "$newVersionCode" \
           --arg newZipUrl "$zipUrl_arm64" \
-          --arg newChangelog "https://raw.githubusercontent.com/anasfanani/Magisk-Tailscaled/master/CHANGELOG.md" \
+          --arg newChangelog "https://raw.githubusercontent.com/${{ github.repository }}/master/CHANGELOG.md" \
           update-arm64.json > temp.json && mv temp.json update-arm64.json
 
     - name: Commit and push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,14 +41,14 @@ jobs:
       run: |
         versionString="$(echo ${{ steps.check_version.outputs.version }}| tr -dc '0-9.')"
         new_tag="${{ steps.check_version.outputs.version }}"
-        zipUrl="https://github.com/anasfanani/Magisk-Tailscaled/releases/download/$new_tag/Magisk-Tailscaled-$new_tag.zip"
+        zipUrl="https://github.com/${{ github.repository }}/releases/download/$new_tag/Magisk-Tailscaled-$new_tag.zip"
         IFS='.' read -ra VERSION_PARTS <<< "$versionString"
         newVersionCode=$(printf "%02d%02d%02d%02d" "${VERSION_PARTS[0]}" "${VERSION_PARTS[1]}" "${VERSION_PARTS[2]}" "${VERSION_PARTS[3]}")
         jq '.version = $newVersion | .versionCode = $newVersionCode | .zipUrl = $newZipUrl | .changelog = $newChangelog' \
           --arg newVersion "$new_tag" \
           --arg newVersionCode "$newVersionCode" \
           --arg newZipUrl "$zipUrl" \
-          --arg newChangelog "https://raw.githubusercontent.com/anasfanani/Magisk-Tailscaled/master/CHANGELOG.txt" \
+          --arg newChangelog "https://raw.githubusercontent.com/${{ github.repository }}/master/CHANGELOG.txt" \
           update.json > temp.json && mv temp.json update.json
         sed -i "s/^version=.*/version=$versionString/" module.prop
         sed -i "s/^versionCode=.*/versionCode=$newVersionCode/" module.prop

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           NEW_TAG="${{ fromJSON(steps.get_latest_release.outputs.data).tag_name }}" 
           VERSION="${{ fromJSON(steps.get_latest_release.outputs.data).name }}"
-          CURRENT_TAG=$(curl -s https://raw.githubusercontent.com/anasfanani/Magisk-Tailscaled/master/files/VERSION.txt)
+          CURRENT_TAG=$(curl -s https://raw.githubusercontent.com/${{ github.repository }}/master/files/VERSION.txt)
           if [[ "$NEW_TAG" == "$CURRENT_TAG" && "${{ github.event.inputs.force }}" != 'true' ]]; then
             echo "Current version is up to date"
             echo "exit=true" >> $GITHUB_OUTPUT
@@ -77,14 +77,14 @@ jobs:
           versionString="${{ steps.check_version.outputs.version }}.0"
           versionString=${versionString//[^0-9.]/}
           new_tag="${{ steps.check_version.outputs.new_tag }}.0"
-          zipUrl="https://github.com/anasfanani/Magisk-Tailscaled/releases/download/$new_tag/Magisk-Tailscaled-$new_tag.zip"
+          zipUrl="https://github.com/${{ github.repository }}/releases/download/$new_tag/Magisk-Tailscaled-$new_tag.zip"
           IFS='.' read -ra VERSION_PARTS <<< "$versionString"
           newVersionCode=$(printf "%02d%02d%02d%02d" "${VERSION_PARTS[0]}" "${VERSION_PARTS[1]}" "${VERSION_PARTS[2]}" "${VERSION_PARTS[3]}")
           jq '.version = $newVersion | .versionCode = $newVersionCode | .zipUrl = $newZipUrl | .changelog = $newChangelog' \
             --arg newVersion "$new_tag" \
             --arg newVersionCode "$newVersionCode" \
             --arg newZipUrl "$zipUrl" \
-            --arg newChangelog "https://raw.githubusercontent.com/anasfanani/Magisk-Tailscaled/master/CHANGELOG.txt" \
+            --arg newChangelog "https://raw.githubusercontent.com/${{ github.repository }}/master/CHANGELOG.txt" \
             update.json > temp.json && mv temp.json update.json
           sed -i "s/^version=.*/version=$versionString/" module.prop
           sed -i "s/^versionCode=.*/versionCode=$newVersionCode/" module.prop


### PR DESCRIPTION
The documentation for [github context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context).